### PR TITLE
Configure custom fonts for site

### DIFF
--- a/_brand.yml
+++ b/_brand.yml
@@ -1,0 +1,3 @@
+version: 5
+font-family-sans-serif: "Montserrat", sans-serif
+headings-font-family: "Kusanagi", sans-serif

--- a/styles.css
+++ b/styles.css
@@ -1,1 +1,20 @@
 /* css styles */
+
+@font-face {
+  font-family: 'Kusanagi';
+  src: url('fonts/Kusanagi.otf') format('opentype');
+  font-weight: normal;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: 'Montserrat';
+  src: url('fonts/MontserratAlternates-Bold.ttf') format('truetype');
+  font-weight: normal;
+  font-style: normal;
+}
+
+.navbar-brand,
+.navbar-nav .nav-link {
+  font-family: var(--bs-heading-font-family);
+}


### PR DESCRIPTION
## Summary
- define Montserrat as body font and Kusanagi for headings via `_brand.yml`
- load local font files and apply Kusanagi to navbar items

## Testing
- `quarto check` *(fails: command not found)*
- `apt-get update` *(fails: repositories 403)*
- `pip install quarto-cli` *(fails: proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_6892623e07bc832da5586769e7b8e1e3